### PR TITLE
refactor: use bitflags instead of manual enum implementation

### DIFF
--- a/crates/ironboyadvance_arm7tdmi/src/lib.rs
+++ b/crates/ironboyadvance_arm7tdmi/src/lib.rs
@@ -16,7 +16,8 @@ pub(crate) enum CpuAction {
     PipelineFlush,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum CpuMode {
     User = 0b10000,
     Fiq = 0b10001,
@@ -25,46 +26,16 @@ pub(crate) enum CpuMode {
     Abort = 0b10111,
     Undefined = 0b11011,
     System = 0b11111,
-    Invalid,
+    #[base]
+    Invalid = 0,
 }
 
-impl CpuMode {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0b10000 => Self::User,
-            0b10001 => Self::Fiq,
-            0b10010 => Self::Irq,
-            0b10011 => Self::Supervisor,
-            0b10111 => Self::Abort,
-            0b11011 => Self::Undefined,
-            0b11111 => Self::System,
-            _ => Self::Invalid,
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CpuState {
+    #[base]
     Arm = 0,
     Thumb = 1,
-}
-
-impl CpuState {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0 => Self::Arm,
-            1 => Self::Thumb,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -352,6 +323,7 @@ pub(crate) enum Exception {
     Fiq = 0x1C,
 }
 
+use bitfields::bitflag;
 use std::mem::size_of;
 use std::ops::RangeInclusive;
 

--- a/crates/ironboyadvance_core/src/dma_control.rs
+++ b/crates/ironboyadvance_core/src/dma_control.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use bitfields::bitfield;
+use bitfields::{bitfield, bitflag};
 use ironboyadvance_common::memory::{MemoryAccess, SystemMemoryAccess};
 use ironboyadvance_common::register_ops::RegisterOps;
 use ironboyadvance_common::scheduler::Scheduler;
@@ -18,29 +18,17 @@ const DMA_OVERFLOW_INTERRUPTS: [InterruptEvent; 4] = [
     InterruptEvent::Dma3Overflow,
 ];
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DestinationControl {
-    Increment,
-    Decrement,
-    Fixed,
-    Reload,
+    #[base]
+    Increment = 0x0,
+    Decrement = 0x1,
+    Fixed = 0x2,
+    Reload = 0x3,
 }
 
 impl DestinationControl {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Increment,
-            0x1 => Self::Decrement,
-            0x2 => Self::Fixed,
-            0x3 => Self::Reload,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-
     pub fn step(&self, bytes: i32) -> i32 {
         match self {
             DestinationControl::Increment | DestinationControl::Reload => bytes,
@@ -50,29 +38,17 @@ impl DestinationControl {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SourceControl {
-    Increment,
-    Decrement,
-    Fixed,
-    Prohibited,
+    #[base]
+    Increment = 0x0,
+    Decrement = 0x1,
+    Fixed = 0x2,
+    Prohibited = 0x3,
 }
 
 impl SourceControl {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Increment,
-            0x1 => Self::Decrement,
-            0x2 => Self::Fixed,
-            0x3 => Self::Prohibited,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-
     pub fn step(&self, bytes: i32) -> i32 {
         match self {
             SourceControl::Increment => bytes,
@@ -82,25 +58,15 @@ impl SourceControl {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ChunkSize {
-    Size16,
-    Size32,
+    #[base]
+    Size16 = 0x0,
+    Size32 = 0x1,
 }
 
 impl ChunkSize {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Size16,
-            0x1 => Self::Size32,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-
     pub fn bit_per_chunk(&self) -> usize {
         match self {
             ChunkSize::Size16 => 16,
@@ -123,28 +89,14 @@ impl ChunkSize {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TimingMode {
-    Immediately,
-    VBlank,
-    HBlank,
-    Special,
-}
-
-impl TimingMode {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Immediately,
-            0x1 => Self::VBlank,
-            0x2 => Self::HBlank,
-            0x3 => Self::Special,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
+    #[base]
+    Immediately = 0x0,
+    VBlank = 0x1,
+    HBlank = 0x2,
+    Special = 0x3,
 }
 
 #[bitfield(u16)]

--- a/crates/ironboyadvance_core/src/ppu/background.rs
+++ b/crates/ironboyadvance_core/src/ppu/background.rs
@@ -1,31 +1,19 @@
-use bitfields::bitfield;
+use bitfields::{bitfield, bitflag};
 use ironboyadvance_common::{bits::SignExtend, memory::SystemMemoryAccess, register_ops::RegisterOps};
 
 use crate::ppu::{SB_ENTRIES, SB_SIDE, color::ColorMode};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ScreenSize {
-    Size0,
-    Size1,
-    Size2,
-    Size3,
+    #[base]
+    Size0 = 0x0,
+    Size1 = 0x1,
+    Size2 = 0x2,
+    Size3 = 0x3,
 }
 
 impl ScreenSize {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Size0,
-            0x1 => Self::Size1,
-            0x2 => Self::Size2,
-            0x3 => Self::Size3,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-
     pub fn text_map_pixel_size(self) -> (u16, u16) {
         match self {
             Self::Size0 => (256, 256),
@@ -95,24 +83,12 @@ impl ScreenBaseBlock {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DisplayAreaOverflow {
-    Transparent,
-    Wraparound,
-}
-
-impl DisplayAreaOverflow {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Transparent,
-            0x1 => Self::Wraparound,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
+    #[base]
+    Transparent = 0x0,
+    Wraparound = 0x1,
 }
 
 #[bitfield(u16)]

--- a/crates/ironboyadvance_core/src/ppu/color.rs
+++ b/crates/ironboyadvance_core/src/ppu/color.rs
@@ -1,22 +1,14 @@
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+use bitfields::bitflag;
+
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ColorMode {
-    Color16,  //4bpp
-    Color256, //8bpp
+    #[base]
+    Color16 = 0x0, //4bpp
+    Color256 = 0x1, //8bpp
 }
 
 impl ColorMode {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Color16,
-            0x1 => Self::Color256,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-
     pub fn bytes_per_tile(self) -> usize {
         match self {
             Self::Color16 => 32,

--- a/crates/ironboyadvance_core/src/ppu/effects.rs
+++ b/crates/ironboyadvance_core/src/ppu/effects.rs
@@ -1,4 +1,4 @@
-use bitfields::bitfield;
+use bitfields::{bitfield, bitflag};
 use ironboyadvance_common::{memory::SystemMemoryAccess, register_ops::RegisterOps};
 
 use crate::ppu::{
@@ -6,28 +6,14 @@ use crate::ppu::{
     color::{bgr555_to_channels, channels_to_bgr555},
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SpecialEffect {
-    None,
-    AlphaBlending,
-    BrightnessIncrease,
-    BrightnessDecrease,
-}
-
-impl SpecialEffect {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0b00 => Self::None,
-            0b01 => Self::AlphaBlending,
-            0b10 => Self::BrightnessIncrease,
-            0b11 => Self::BrightnessDecrease,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
+    #[base]
+    None = 0b00,
+    AlphaBlending = 0b01,
+    BrightnessIncrease = 0b10,
+    BrightnessDecrease = 0b11,
 }
 
 #[bitfield(u16)]

--- a/crates/ironboyadvance_core/src/ppu/lcd.rs
+++ b/crates/ironboyadvance_core/src/ppu/lcd.rs
@@ -1,55 +1,29 @@
-use bitfields::bitfield;
+use bitfields::{bitfield, bitflag};
 
 use ironboyadvance_common::register_ops::RegisterOps;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum BgMode {
-    Mode0,
-    Mode1,
-    Mode2,
-    Mode3,
-    Mode4,
-    Mode5,
-    Prohibited,
+    Mode0 = 0x0,
+    Mode1 = 0x1,
+    Mode2 = 0x2,
+    Mode3 = 0x3,
+    Mode4 = 0x4,
+    Mode5 = 0x5,
+    #[base]
+    Prohibited = 0xFF,
 }
 
-impl BgMode {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Mode0,
-            0x1 => Self::Mode1,
-            0x2 => Self::Mode2,
-            0x3 => Self::Mode3,
-            0x4 => Self::Mode4,
-            0x5 => Self::Mode5,
-            _ => Self::Prohibited,
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FrameSelection {
-    Frame0,
-    Frame1,
+    #[base]
+    Frame0 = 0,
+    Frame1 = 1,
 }
 
 impl FrameSelection {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0 => Self::Frame0,
-            1 => Self::Frame1,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-
     pub fn base_address(self) -> usize {
         match self {
             Self::Frame0 => 0,

--- a/crates/ironboyadvance_core/src/ppu/object.rs
+++ b/crates/ironboyadvance_core/src/ppu/object.rs
@@ -1,4 +1,4 @@
-use bitfields::bitfield;
+use bitfields::{bitfield, bitflag};
 use getset::CopyGetters;
 use ironboyadvance_common::bits::SignExtend;
 
@@ -14,74 +14,34 @@ const OBJECT_SIZES: [[(u16, u16); 4]; 3] = [
     [(8, 16), (8, 32), (16, 32), (32, 64)], // Vertical
 ];
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum AffineMode {
-    NoAffine,
-    Affine,
-    Hidden,
-    AffineDouble,
+    #[base]
+    NoAffine = 0,
+    Affine = 1,
+    Hidden = 2,
+    AffineDouble = 3,
 }
 
-impl AffineMode {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::NoAffine,
-            0x1 => Self::Affine,
-            0x2 => Self::Hidden,
-            0x3 => Self::AffineDouble,
-            _ => unreachable!(),
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ObjectMode {
-    Normal,
-    SemiTransparent,
-    ObjectWindow,
-    Prohibited,
+    Normal = 0,
+    SemiTransparent = 1,
+    ObjectWindow = 2,
+    #[base]
+    Prohibited = 0xFF,
 }
 
-impl ObjectMode {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Normal,
-            0x1 => Self::SemiTransparent,
-            0x2 => Self::ObjectWindow,
-            _ => Self::Prohibited,
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[bitflag(u8)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ObjectShape {
-    Square,
-    Horizontal,
-    Vertical,
-    Prohibited,
-}
-
-impl ObjectShape {
-    pub const fn from_bits(bits: u8) -> Self {
-        match bits {
-            0x0 => Self::Square,
-            0x1 => Self::Horizontal,
-            0x2 => Self::Vertical,
-            _ => Self::Prohibited,
-        }
-    }
-
-    pub const fn into_bits(self) -> u8 {
-        self as u8
-    }
+    Square = 0x0,
+    Horizontal = 0x1,
+    Vertical = 0x2,
+    #[base]
+    Prohibited = 0xFF,
 }
 
 #[bitfield(u16)]


### PR DESCRIPTION
Bitfields has a feature called [Bitflags](https://github.com/gregorygaines/bitfields-rs#bitflags) which automatically generates bitflag implementations for annotated enums:

```rust
#[bitflag(u8)]
#[derive(Debug, PartialEq, Eq)]
pub enum DisplayAreaOverflow {
    #[base]
    Transparent = 0x0,
    Wraparound = 0x1,
}

/// The code that's generated for the `DisplayAreaOverflow` 
/// by the `#[bitflag]` attribute saving you the trouble of
/// writing the `from_bits` and `into_bits` functions yourself.
// impl DisplayAreaOverflow {
//     const fn from_bits(bits: u8) -> Self {
//         match bits {
//             0x0 => Self::Transparent,
//             0x1 => Self::Wraparound,
//             _ => Self::Transparent
//         }
//     }
//
//     const fn into_bits(self) -> u8 {
//         self as u8
//     }
// }
```

As a show of good faith, I've decided to update your repository to take advantage of this new feature!